### PR TITLE
feat: WP-127 add suggestion chips for first-time chat users

### DIFF
--- a/apps/alpha-whale/web/components/chat-panel.tsx
+++ b/apps/alpha-whale/web/components/chat-panel.tsx
@@ -262,7 +262,10 @@ export function ChatPanel({ onSymbolChange, onStudyToggle }: ChatPanelProps) {
     }
   };
 
-  const isInitialState = messages.length === 1 && messages[0] === WELCOME_MESSAGE;
+  const isInitialState =
+    messages.length === 1 &&
+    messages[0]?.role === "assistant" &&
+    messages[0]?.content === WELCOME_MESSAGE.content;
 
   const handleChipClick = (prompt: string) => {
     setInput(prompt);
@@ -383,14 +386,16 @@ export function ChatPanel({ onSymbolChange, onStudyToggle }: ChatPanelProps) {
         {isInitialState && (
           <div className="flex gap-2 mt-2 overflow-x-auto scrollbar-hidden pb-1">
             {SUGGESTION_CHIPS.map((chip) => (
-              <button
+              <Button
                 key={chip.label}
+                variant="outline"
+                size="sm"
                 onClick={() => handleChipClick(chip.prompt)}
-                className="flex items-center gap-2 px-3 py-1.5 rounded-full border bg-card hover:bg-accent text-sm text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap shrink-0"
+                className="rounded-full text-muted-foreground hover:text-foreground"
               >
-                <chip.icon className="h-4 w-4" />
-                <span>{chip.label}</span>
-              </button>
+                <chip.icon />
+                {chip.label}
+              </Button>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary                                                                                                                 
  - Adds horizontal scrollable suggestion chips below chat input for first-time users                                                                                                                                   
  - Chips auto-disappear after the user sends their first message                                                                                                                                                       
  - Clicking a chip populates the input field for review before sending                                                                                                                                                 
  - 5 domain-specific suggestions: stock price, compare assets, add indicator, technical analysis, crypto check                                                                                                         
                                                                                                                                                                                                                        
  Relates to hcslomeu/alpha-whale#101                                                                                                                                                                                            
                                                                                                                                                                                                                        
  ## Test plan                                                                                                                                                                                                          
  - [ ] Verify chips appear on initial load (only welcome message visible)                            
  - [ ] Click a chip — input field populates with the prompt                                                                                                                                                            
  - [ ] Send a message — chips disappear permanently                                                                                                                                                                    
  - [ ] Horizontal scroll works when container is narrow                                                                                                                                                                
  - [ ] Build passes: pnpm nx build alpha-whale-web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added suggestion chips with icons and labels to the chat panel.
  * Chips appear only at the start of a new conversation and can be clicked to populate the message input with suggested prompts.
  * Chip selection is integrated into the input flow so chosen prompts can be edited and sent as messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->